### PR TITLE
FIX: issue with partial flush in fullhtml on Linux.

### DIFF
--- a/ioutput.h
+++ b/ioutput.h
@@ -272,7 +272,10 @@ class IFilter : public IOutput<T>
 {
 public:
   IFilter(IOutput<T>* output) : m_output(output) { };
-  virtual ~IFilter() = default;
+  virtual ~IFilter()
+  {
+    delete m_output;
+  }
 
   void Start() override
   {
@@ -316,7 +319,10 @@ class ITransform : public IOutput<T>
 {
 public:
   ITransform(IOutput<T>* output) : m_output(output) { };
-  virtual ~ITransform() = default;
+  virtual ~ITransform() 
+  {
+    delete m_output;
+  }
 
   void Start() override
   {

--- a/logparserworker.cpp
+++ b/logparserworker.cpp
@@ -240,7 +240,7 @@ void LogParserWorker::Run(const ProgramOptions &optionsSrc)
     return nullptr;
   };
 
-  MultipleOutput<Warning> pathFilterPipeline;
+  auto pathFilterPipeline = std::make_unique<MultipleOutput<Warning>>();
   for (const auto &format : formats)
   {
     auto f = format(options);
@@ -269,57 +269,57 @@ void LogParserWorker::Run(const ProgramOptions &optionsSrc)
                               || IsA<TaskListOutput>(f)  || IsA<TaskListVerboseOutput>(f)))
       {  
         auto help = std::make_unique<HelpMessageOutput>(std::move(f));
-        pathFilterPipeline.Add(std::unique_ptr<IOutput<Warning>>(generateOutput(std::move(help))));
+        pathFilterPipeline->Add(std::unique_ptr<IOutput<Warning>>(generateOutput(std::move(help))));
       }
       else if (IsA<HTMLOutput>(f))
       {
-        pathFilterPipeline.Add(std::make_unique<LevelTransform>(std::unique_ptr<IOutput<Warning>>(generateOutput(std::move(f))), options));
+        pathFilterPipeline->Add(std::make_unique<LevelTransform>(std::unique_ptr<IOutput<Warning>>(generateOutput(std::move(f))), options));
       }
       else
       {
-        pathFilterPipeline.Add(std::unique_ptr<IOutput<Warning>>(generateOutput(std::move(f))));
+        pathFilterPipeline->Add(std::unique_ptr<IOutput<Warning>>(generateOutput(std::move(f))));
       }
     }
   }
 
-  MultipleOutput<Warning> transformPipeline;
-  if (!pathFilterPipeline.empty())
+  auto transformPipeline = std::make_unique<MultipleOutput<Warning>>();
+  if (!pathFilterPipeline->empty())
   {
-    transformPipeline.Add(std::make_unique<PathFilter>(&pathFilterPipeline, options));
+    transformPipeline->Add(std::make_unique<PathFilter>(pathFilterPipeline.release(), options));
   }
   
-  MultipleOutput<Warning> noTransformPipeline;
+  auto noTransformPipeline = std::make_unique<MultipleOutput<Warning>>();
   if (jsonOutput)
   {
-    noTransformPipeline.Add(std::move(jsonOutput));
+    noTransformPipeline->Add(std::move(jsonOutput));
   }
   if (gitlabOutput)
   {
-    noTransformPipeline.Add(std::make_unique<SourceRootRemover>(std::move(gitlabOutput), options));
+    noTransformPipeline->Add(std::make_unique<SourceRootRemover>(std::move(gitlabOutput), options));
   }
 
-  MultipleOutput<Warning> filterPipeline;
-  if (!transformPipeline.empty())
+  auto filterPipeline = std::make_unique<MultipleOutput<Warning>>();
+  if (!transformPipeline->empty())
   {
-    filterPipeline.Add(std::make_unique<SourceRootTransformer>(&transformPipeline, options));
+    filterPipeline->Add(std::make_unique<SourceRootTransformer>(transformPipeline.release(), options));
   }
 
-  if (!noTransformPipeline.empty())
+  if (!noTransformPipeline->empty())
   {
-    filterPipeline.Add(std::make_unique<PathFilter>(&noTransformPipeline, options));
+    filterPipeline->Add(std::make_unique<PathFilter>(noTransformPipeline.release(), options));
   }
 
-  MultipleOutput<Warning> outputsPipeline;
-  if (!filterPipeline.empty())
+  auto outputsPipeline = std::make_unique<MultipleOutput<Warning>>();
+  if (!filterPipeline->empty())
   {
-    outputsPipeline.Add(std::make_unique<MessageFilter>(&filterPipeline, options));
+    outputsPipeline->Add(std::make_unique<MessageFilter>(filterPipeline.release(), options));
   }
 
-  MultipleOutput<Warning> misraPathFilterPipline;
+  auto misraPathFilterPipline = std::make_unique<MultipleOutput<Warning>>();
   if (misraCompliance)
   {
-    misraPathFilterPipline.Add(std::make_unique<PathFilter>(misraCompliance.get(), options));
-    outputsPipeline.Add(std::make_unique<SourceRootTransformer>(&misraPathFilterPipline, options));
+    misraPathFilterPipline->Add(std::make_unique<PathFilter>(misraCompliance.get(), options));
+    outputsPipeline->Add(std::make_unique<SourceRootTransformer>(misraPathFilterPipline.release(), options));
   }
   else
   {
@@ -334,13 +334,13 @@ void LogParserWorker::Run(const ProgramOptions &optionsSrc)
     }
   }
 
-  MultipleOutput<Warning> output;
-  if (!outputsPipeline.empty())
+  auto output = std::make_unique<MultipleOutput<Warning>>();
+  if (!outputsPipeline->empty())
   {
-    output.Add(std::make_unique<SameWarningsAdaptor>(&outputsPipeline));
+    output->Add(std::make_unique<SameWarningsAdaptor>(outputsPipeline.release()));
   }
 
-  ParseLog(inputFiles, output, options.projectRoot);
+  ParseLog(inputFiles, *output, options.projectRoot);
 
   std::cout << "Total messages: " << m_countTotal << '\n'
             << "Filtered messages: " << m_countSuccess << std::endl;

--- a/sourcetreerootremover.h
+++ b/sourcetreerootremover.h
@@ -16,10 +16,7 @@ namespace PlogConverter
   {
   public:
     explicit SourceRootRemover(std::unique_ptr<IOutput<Warning>> output, const ProgramOptions &options);
-    ~SourceRootRemover() override
-    {
-      delete m_output;
-    }
+    ~SourceRootRemover() override = default;
 
   private:
     Warning Transform(Warning message) const override;
@@ -38,11 +35,7 @@ namespace PlogConverter
       , m_options{ options }
     {
     }
-
-    ~SourceRootChecker() override
-    {
-      delete m_output;
-    }
+    ~SourceRootChecker() override = default;
 
   private:
     bool Check(const Warning &warning) const override


### PR DESCRIPTION
IMPORTANT -- `m_output` data member of `IFilter` and `ITransform` are now deleted in these classes, not in `SourceRootDeleter` and `SourceRootChecker`.